### PR TITLE
Fix/update way to pass minimist options to meow 4

### DIFF
--- a/packages/conventional-github-releaser/src/cli.js
+++ b/packages/conventional-github-releaser/src/cli.js
@@ -38,18 +38,35 @@ const cli = meow({
 
       -d, --draft               Publishes a draft instead of a real release
                                 Default: false
-  `
-}, {
-  alias: {
-    u: 'url',
-    t: 'token',
-    p: 'preset',
-    k: 'pkg',
-    r: 'releaseCount',
-    v: 'verbose',
-    n: 'config',
-    c: 'context',
-    d: 'draft'
+  `,
+  flags: {
+    url: {
+      alias: 'u'
+    },
+    token: {
+      alias: 't'
+    },
+    preset: {
+      alias: 'p'
+    },
+    pkg: {
+      alias: 'k'
+    },
+    releaseCount: {
+      alias: 'r'
+    },
+    verbose: {
+      alias: 'v'
+    },
+    config: {
+      alias: 'n'
+    },
+    context: {
+      alias: 'c'
+    },
+    draft: {
+      alias: 'd'
+    }
   }
 })
 

--- a/packages/conventional-github-releaser/src/cli.js
+++ b/packages/conventional-github-releaser/src/cli.js
@@ -41,31 +41,40 @@ const cli = meow({
   `,
   flags: {
     url: {
-      alias: 'u'
+      alias: 'u',
+      type: 'string'
     },
     token: {
-      alias: 't'
+      alias: 't',
+      type: 'string'
     },
     preset: {
-      alias: 'p'
+      alias: 'p',
+      type: 'string'
     },
     pkg: {
-      alias: 'k'
+      alias: 'k',
+      type: 'string'
     },
     releaseCount: {
-      alias: 'r'
+      alias: 'r',
+      type: 'number'
     },
     verbose: {
-      alias: 'v'
+      alias: 'v',
+      type: 'boolean'
     },
     config: {
-      alias: 'n'
+      alias: 'n',
+      type: 'string'
     },
     context: {
-      alias: 'c'
+      alias: 'c',
+      type: 'string'
     },
     draft: {
-      alias: 'd'
+      alias: 'd',
+      type: 'boolean'
     }
   }
 })

--- a/packages/conventional-github-releaser/src/cli.js
+++ b/packages/conventional-github-releaser/src/cli.js
@@ -42,6 +42,7 @@ const cli = meow({
   flags: {
     url: {
       alias: 'u',
+      default: 'https://api.github.com',
       type: 'string'
     },
     token: {
@@ -58,10 +59,12 @@ const cli = meow({
     },
     releaseCount: {
       alias: 'r',
+      default: 1,
       type: 'number'
     },
     verbose: {
       alias: 'v',
+      default: 'false',
       type: 'boolean'
     },
     config: {
@@ -74,6 +77,7 @@ const cli = meow({
     },
     draft: {
       alias: 'd',
+      default: false,
       type: 'boolean'
     }
   }

--- a/packages/conventional-gitlab-releaser/src/cli.js
+++ b/packages/conventional-gitlab-releaser/src/cli.js
@@ -35,17 +35,32 @@ const cli = meow({
                                 This value is ignored if preset is specified
 
       -c, --context             A filepath of a javascript that is used to define template constntiables
-  `
-}, {
-  alias: {
-    u: 'url',
-    t: 'token',
-    p: 'preset',
-    k: 'pkg',
-    r: 'releaseCount',
-    v: 'verbose',
-    n: 'config',
-    c: 'context'
+  `,
+  flags: {
+    url: {
+      alias: 'u'
+    },
+    token: {
+      alias: 't'
+    },
+    preset: {
+      alias: 'p'
+    },
+    pkg: {
+      alias: 'k'
+    },
+    releaseCount: {
+      alias: 'r'
+    },
+    verbose: {
+      alias: 'v'
+    },
+    config: {
+      alias: 'n'
+    },
+    context: {
+      alias: 'c'
+    }
   }
 })
 

--- a/packages/conventional-gitlab-releaser/src/cli.js
+++ b/packages/conventional-gitlab-releaser/src/cli.js
@@ -39,6 +39,7 @@ const cli = meow({
   flags: {
     url: {
       alias: 'u',
+      default: 'https://api.github.com',
       type: 'string'
     },
     token: {
@@ -55,10 +56,12 @@ const cli = meow({
     },
     releaseCount: {
       alias: 'r',
+      default: 1,
       type: 'number'
     },
     verbose: {
       alias: 'v',
+      default: 'false',
       type: 'boolean'
     },
     config: {

--- a/packages/conventional-gitlab-releaser/src/cli.js
+++ b/packages/conventional-gitlab-releaser/src/cli.js
@@ -38,28 +38,36 @@ const cli = meow({
   `,
   flags: {
     url: {
-      alias: 'u'
+      alias: 'u',
+      type: 'string'
     },
     token: {
-      alias: 't'
+      alias: 't',
+      type: 'string'
     },
     preset: {
-      alias: 'p'
+      alias: 'p',
+      type: 'string'
     },
     pkg: {
-      alias: 'k'
+      alias: 'k',
+      type: 'string'
     },
     releaseCount: {
-      alias: 'r'
+      alias: 'r',
+      type: 'number'
     },
     verbose: {
-      alias: 'v'
+      alias: 'v',
+      type: 'boolean'
     },
     config: {
-      alias: 'n'
+      alias: 'n',
+      type: 'string'
     },
     context: {
-      alias: 'c'
+      alias: 'c',
+      type: 'string'
     }
   }
 })

--- a/packages/conventional-gitlab-releaser/src/cli.js
+++ b/packages/conventional-gitlab-releaser/src/cli.js
@@ -39,7 +39,7 @@ const cli = meow({
   flags: {
     url: {
       alias: 'u',
-      default: 'https://api.github.com',
+      default: 'https://gitlab.com',
       type: 'string'
     },
     token: {


### PR DESCRIPTION
The first commit is the one that fixes the issue where trying to use `flags.token` will have undefined value if the token was passed using the alias `-t`. The second commit is a recommendation from meow@4.0.0 documentation. The addition of default values is optional. 

This fixes #63.