### PR TITLE
Update to Conventional changelog 3.1.x

### DIFF
--- a/packages/conventional-github-releaser/package.json
+++ b/packages/conventional-github-releaser/package.json
@@ -36,7 +36,7 @@
   },
   "version": "3.1.3",
   "dependencies": {
-    "conventional-changelog": "^2.0.0",
+    "conventional-changelog": "^3.1.8",
     "dateformat": "^3.0.0",
     "debug": "^3.1.0",
     "gh-got": "^7.0.0",

--- a/packages/conventional-github-releaser/src/cli.js
+++ b/packages/conventional-github-releaser/src/cli.js
@@ -91,6 +91,7 @@ let templateContext
 let gitRawCommitsOpts
 let parserOpts
 let writerOpts
+let presetConfig
 
 try {
   if (flags.context) {
@@ -112,13 +113,17 @@ try {
   if (config.writerOpts) {
     writerOpts = config.writerOpts
   }
+
+  if (config.presetConfig) {
+    presetConfig = config.presetConfig
+  }
 } catch (err) {
   console.error('Failed to get file. ' + err)
   process.exit(1)
 }
 
 const changelogOpts = {
-  preset: flags.preset,
+  preset: Object.assign({ name: flags.preset }, presetConfig),
   pkg: {
     path: flags.pkg
   },

--- a/packages/conventional-github-releaser/src/index.js
+++ b/packages/conventional-github-releaser/src/index.js
@@ -11,6 +11,15 @@ const semver = require('semver')
 const through = require('through2')
 const transform = require('./transform')
 
+function parseChangelogOpts(changelogOpts) {
+  let preset = changelogOpts.preset
+
+  return merge(
+    changelogOpts,
+    {preset: typeof preset ==='string' ? {name: preset} : preset}
+  )
+}
+
 /* eslint max-params: ["error", 7] */
 function conventionalGithubReleaser (auth, changelogOpts, context, gitRawCommitsOpts, parserOpts, writerOpts, userCb) {
   if (!auth) {
@@ -41,6 +50,8 @@ function conventionalGithubReleaser (auth, changelogOpts, context, gitRawCommits
     transform: transform,
     releaseCount: 1
   }, changelogOpts)
+
+  changelogOpts = parseChangelogOpts(changelogOpts)
 
   writerOpts.includeDetails = true
 


### PR DESCRIPTION
Updates the reference to new conventional-changelog core. Adjusts preset option passing as it has changed between releases.

Adds ability to configure preset from config.