### PR TITLE
fix: gitlab release creation

### DIFF
--- a/packages/conventional-gitlab-releaser/README.md
+++ b/packages/conventional-gitlab-releaser/README.md
@@ -92,7 +92,7 @@ Please use this [gist](https://gist.github.com/stevemao/280ef22ee861323993a0) to
 
 ### Required GitLab CE/EE Edition
 
-Version [9.0](https://about.gitlab.com/2017/03/22/gitlab-9-0-released/#api-v4-ce-ees-eep), or higher, of GitLab CE/EE is required for `conventional-gitlab-releaser`.
+Version [11.11](https://about.gitlab.com/releases/2019/05/22/gitlab-11-11-released), or higher, of GitLab CE/EE is required for `conventional-gitlab-releaser`.
 
 Core features used:
 * [GitLab release page](http://docs.gitlab.com/ce/workflow/releases.html)

--- a/packages/conventional-gitlab-releaser/src/index.js
+++ b/packages/conventional-gitlab-releaser/src/index.js
@@ -73,14 +73,14 @@ function conventionalGitlabReleaser (auth, changelogOpts, context, gitRawCommits
             return
           }
 
-          const url = `projects/${escape(context.owner + `/` + context.repository)}/repository/tags`
+          const url = `projects/${escape(context.owner + `/` + context.repository)}/releases`
           const options = {
             endpoint: auth.url,
             body: {
               tag_name: chunk.keyCommit.version,
               ref: chunk.keyCommit.hash,
-              message: 'Release ' + chunk.keyCommit.version,
-              release_description: chunk.log
+              name: chunk.keyCommit.version,
+              description: chunk.log
             }
           }
           debug(`posting %o to the following URL - ${url}`, options)


### PR DESCRIPTION
Creating release on `repository/tags` endpoint has been deprecated and marked for removal on gitlab.
This causes non-zero exit codes, therefore, breaking automatic CI pipelines.

Fixes #204

ps: I removed the `Release ` prefix, I think it wasn't used previously (at least I haven't seen it in our projects where a couple of hundreds of releases were created by this module).

update: I had to remove `packages/conventional-tidelift-releaser/changelog.md` (not to be confused with CHANGELOG.md), which was empty file I guess accidentally pushed, but the default OSX file system is case insensitive) 