### PR TITLE
github: enable generate release notes

### DIFF
--- a/packages/conventional-github-releaser/src/index.js
+++ b/packages/conventional-github-releaser/src/index.js
@@ -82,6 +82,7 @@ function conventionalGithubReleaser (auth, changelogOpts, context, gitRawCommits
               name: changelogOpts.name || chunk.keyCommit.version,
               prerelease: semver.parse(chunk.keyCommit.version).prerelease.length > 0,
               tag_name: chunk.keyCommit.version,
+              generate_release_notes: true,
               target_commitish: changelogOpts.targetCommitish
             }
           }


### PR DESCRIPTION
This is a new GitHub feature. You can read more about that

https://github.blog/2021-10-04-beta-github-releases-improving-release-experience/

Also related:

https://github.com/MylesBorins/node-osc/blob/main/.github/workflows/create-release.yml#L39